### PR TITLE
Use configured REST API URL in mailman3 commander

### DIFF
--- a/src/mailman3commander/mailman3commander.py
+++ b/src/mailman3commander/mailman3commander.py
@@ -64,10 +64,11 @@ class Mailman3Commander():
         url = '{schema}://{host}:{port}'.format(schema=s, host=host, port=port)
 
         # And test it using the credentials:
+        api_url = f"{url}/3.1"
         try:
-            client = Client('http://localhost:8001/3.1', user, pw)
+            client = Client(api_url, user, pw)
         except Exception as exc:
-            printerr(_T('Exception accesing REST API URL = {}').format(url))
+            printerr(_T('Exception accessing REST API URL = {}').format(api_url))
             printerr(exc)
             return(False)
         if 'api_version' in client.system.keys():


### PR DESCRIPTION
## Summary
- use the configured host and port when creating the Mailman3 REST client
- update error message to report the full REST API URL

## Testing
- `python -m py_compile src/mailman3commander/mailman3commander.py`


------
https://chatgpt.com/codex/tasks/task_e_68a85237e0f4832f883b007255205238