### PR TITLE
chore: drop tqdm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ and python3 mailman3commander.py)
 
 
 # Libraries in use
-https://pypi.org/project/simple-term-menu/
-https://pypi.org/project/mailmanclient/
+
+- [simple-term-menu](https://pypi.org/project/simple-term-menu/)
+- [buanzobasics](https://pypi.org/project/buanzobasics/)
+- [mailmanclient](https://pypi.org/project/mailmanclient/)
 
 # Libraries I would like to use:
 https://pypi.org/project/easy-ansi/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-tqdm
 simple_term_menu
 buanzobasics
 mailmanclient


### PR DESCRIPTION
## Summary
- remove `tqdm` from requirements
- document remaining dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a8b4e82130832fb7c6e32658bbb05c