### PR TITLE
Add gettext internationalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 dist/
 send.sh
+*.mo

--- a/README.md
+++ b/README.md
@@ -45,6 +45,32 @@ python -m pip install --upgrade build
 python -m build
 ```
 
+# Translations
+
+`mailman3commander` uses [gettext](https://docs.python.org/3/library/gettext.html)
+for internationalization. Message catalogs live under
+`src/mailman3commander/locale`.
+
+To update the template file run:
+
+```bash
+xgettext -k_T -o src/mailman3commander/locale/mailman3commander.pot src/mailman3commander/mailman3commander.py
+```
+
+To start a new translation copy the template and edit the resulting `.po`
+file:
+
+```bash
+cp src/mailman3commander/locale/mailman3commander.pot src/mailman3commander/locale/<lang>/LC_MESSAGES/mailman3commander.po
+```
+
+Finally compile the catalog to a binary `.mo` file so it can be used at
+runtime:
+
+```bash
+msgfmt src/mailman3commander/locale/<lang>/LC_MESSAGES/mailman3commander.po -o src/mailman3commander/locale/<lang>/LC_MESSAGES/mailman3commander.mo
+```
+
 # Libraries in use
 
 - [simple-term-menu](https://pypi.org/project/simple-term-menu/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,13 @@ m3c = "mailman3commander.mailman3commander:run"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"mailman3commander" = ["locale/mailman3commander.pot", "locale/*/LC_MESSAGES/*.po"]
 
 [tool.setuptools.dynamic]
 version = {attr = "mailman3commander.__version__"}

--- a/src/mailman3commander/locale/es/LC_MESSAGES/mailman3commander.po
+++ b/src/mailman3commander/locale/es/LC_MESSAGES/mailman3commander.po
@@ -1,0 +1,186 @@
+# Spanish translations for mailman3commander.
+# This file is distributed under the same license as the package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: mailman3commander\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-22 22:07+0000\n"
+"PO-Revision-Date: 2025-08-22 00:00+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/mailman3commander/mailman3commander.py:55
+msgid "Exception reading {}: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:59
+msgid "No webservice section found: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:60
+msgid "Are you sure this is the correct path?"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:80
+msgid "Exception accessing REST API URL = {}: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:106
+msgid "Main Menu"
+msgstr "Menú principal"
+
+#: src/mailman3commander/mailman3commander.py:185
+msgid "Global Configuration Browser"
+msgstr "Explorador de configuración global"
+
+#: src/mailman3commander/mailman3commander.py:186
+msgid "Choose a section from the menu, or hit ESC to go back"
+msgstr "Elija una sección del menú o presione ESC para volver"
+
+#: src/mailman3commander/mailman3commander.py:200
+msgid "Membership"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:202
+msgid "Add Member"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:205
+msgid "Manage"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:226
+msgid "Settings"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:244
+msgid "Enter the email address to subscribe: "
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:250
+msgid "Member {} added to {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:252
+msgid "Error subscribing {}: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:253
+#: src/mailman3commander/mailman3commander.py:271
+#: src/mailman3commander/mailman3commander.py:299
+#: src/mailman3commander/mailman3commander.py:317
+msgid "Press Enter to continue"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:258
+msgid "Member"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:260
+#: src/mailman3commander/mailman3commander.py:262
+msgid "Remove from list"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:263
+msgid "Type \"yes\" to confirm removal of {}: "
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:268
+msgid "{} removed"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:270
+msgid "Error removing {}: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:277
+#, python-brace-format
+msgid "New value for {k} (current: {c}): "
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:296
+msgid "Setting updated"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:298
+msgid "Error updating setting: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:305
+msgid "Deletion"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:305
+msgid "Are you sure?"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:306
+msgid "No"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:306
+#: src/mailman3commander/mailman3commander.py:308
+msgid "Yes, delete"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:309
+msgid "Type the list name ({}) to confirm: "
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:314
+msgid "List {} deleted"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:316
+msgid "Error deleting list: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:358
+msgid "FULL SUBJECT"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:359
+msgid "MESSAGE ID"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:360
+msgid "REASON"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:383
+#: src/mailman3commander/mailman3commander.py:400
+#: src/mailman3commander/mailman3commander.py:410
+msgid "Moderation Tasks"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:384
+msgid "Held Messages"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:386
+msgid "You can choose a message below to visualize and act upon."
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:399
+msgid "Management"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:400
+#: src/mailman3commander/mailman3commander.py:406
+msgid "List Configuration"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:400
+#: src/mailman3commander/mailman3commander.py:408
+msgid "Membership Management"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:400
+#: src/mailman3commander/mailman3commander.py:412
+msgid "Delete List"
+msgstr ""

--- a/src/mailman3commander/locale/mailman3commander.pot
+++ b/src/mailman3commander/locale/mailman3commander.pot
@@ -1,0 +1,189 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-22 22:07+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/mailman3commander/mailman3commander.py:55
+msgid "Exception reading {}: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:59
+msgid "No webservice section found: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:60
+msgid "Are you sure this is the correct path?"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:80
+msgid "Exception accessing REST API URL = {}: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:106
+msgid "Main Menu"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:185
+msgid "Global Configuration Browser"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:186
+msgid "Choose a section from the menu, or hit ESC to go back"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:200
+msgid "Membership"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:202
+msgid "Add Member"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:205
+msgid "Manage"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:226
+msgid "Settings"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:244
+msgid "Enter the email address to subscribe: "
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:250
+msgid "Member {} added to {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:252
+msgid "Error subscribing {}: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:253
+#: src/mailman3commander/mailman3commander.py:271
+#: src/mailman3commander/mailman3commander.py:299
+#: src/mailman3commander/mailman3commander.py:317
+msgid "Press Enter to continue"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:258
+msgid "Member"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:260
+#: src/mailman3commander/mailman3commander.py:262
+msgid "Remove from list"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:263
+msgid "Type \"yes\" to confirm removal of {}: "
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:268
+msgid "{} removed"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:270
+msgid "Error removing {}: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:277
+#, python-brace-format
+msgid "New value for {k} (current: {c}): "
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:296
+msgid "Setting updated"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:298
+msgid "Error updating setting: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:305
+msgid "Deletion"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:305
+msgid "Are you sure?"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:306
+msgid "No"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:306
+#: src/mailman3commander/mailman3commander.py:308
+msgid "Yes, delete"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:309
+msgid "Type the list name ({}) to confirm: "
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:314
+msgid "List {} deleted"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:316
+msgid "Error deleting list: {}"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:358
+msgid "FULL SUBJECT"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:359
+msgid "MESSAGE ID"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:360
+msgid "REASON"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:383
+#: src/mailman3commander/mailman3commander.py:400
+#: src/mailman3commander/mailman3commander.py:410
+msgid "Moderation Tasks"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:384
+msgid "Held Messages"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:386
+msgid "You can choose a message below to visualize and act upon."
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:399
+msgid "Management"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:400
+#: src/mailman3commander/mailman3commander.py:406
+msgid "List Configuration"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:400
+#: src/mailman3commander/mailman3commander.py:408
+msgid "Membership Management"
+msgstr ""
+
+#: src/mailman3commander/mailman3commander.py:400
+#: src/mailman3commander/mailman3commander.py:412
+msgid "Delete List"
+msgstr ""

--- a/src/mailman3commander/mailman3commander.py
+++ b/src/mailman3commander/mailman3commander.py
@@ -15,15 +15,23 @@ import argparse
 import configparser
 import logging
 import shutil
+import os
+import gettext
 from mailmanclient import Client
 from simple_term_menu import TerminalMenu
 from buanzobasics.buanzobasics import valueOrDefault
 from email import policy
 from email.parser import BytesParser
 
-def _T(msgid):
-    # Proxy for i18n
-    return(msgid)
+
+LOCALE_DIR = os.path.join(os.path.dirname(__file__), 'locale')
+translation = gettext.translation('mailman3commander', localedir=LOCALE_DIR, fallback=True)
+_ = translation.gettext
+
+
+def _T(msgid: str) -> str:
+    """Translate *msgid* using the active gettext catalog."""
+    return _(msgid)
 
 class Mailman3Commander():
     def __init__(self, configpath):


### PR DESCRIPTION
## Summary
- set up gettext translations and replace `_T` with wrapper
- document translation workflow
- add translation template and Spanish example catalog
- ignore compiled `.mo` files and remove them from package data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=src LANGUAGE=es python - <<'PY'
from mailman3commander import mailman3commander as m
print(m._T('Global Configuration Browser'))
print(m._T('Choose a section from the menu, or hit ESC to go back'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8e9dea138832fb2d59abb276b77a8