### PR TITLE
Add Docker Mailman helpers and reconnect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,36 @@ Until then you can run the project from source:
 
 3. Invoke the console script:
 
-   ```bash
-   m3c
-   ```
+```bash
+m3c
+```
+
+## Docker helper functions
+
+Some administrative tasks are easier to perform through the classic Mailman
+CLI.  The module :mod:`mailman3commander.docker_mailman` provides thin wrappers
+around ``docker compose exec -T mailman-core`` so these commands can be
+invoked from Python:
+
+```python
+from mailman3commander import list_lists, list_members, add_members
+
+stdout, stderr, rc = list_lists()
+print(stdout)
+```
+
+The helpers expose ``list_members`` and ``add_members`` as well, all returning a
+``(stdout, stderr, returncode)`` tuple for further processing.
+
+## Reconnecting after ``setup.sh``
+
+When the ``setup.sh`` script that bootstraps the Mailman stack exits the
+services remain running in the background.  Use the script in
+``examples/manager_reconnect.sh`` to reattach and launch the commander menu:
+
+```bash
+./examples/manager_reconnect.sh
+```
 
 ### Build
 

--- a/examples/manager_reconnect.sh
+++ b/examples/manager_reconnect.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Example: reconnect to the Mailman core container after ``setup.sh`` completes.
+#
+# The ``setup.sh`` script that initializes the Mailman 3 stack typically exits
+# after bringing the containers up.  The services keep running in the
+# background.  This helper script shows how an administrator can reconnect and
+# run management commands again.
+
+# List available mailing lists
+# (equivalent to ``mailman lists`` inside the container)
+docker compose exec -T mailman-core mailman lists
+
+# Start the interactive Mailman3 Commander menu
+# (requires ``mailman3commander`` to be installed inside the container)
+docker compose exec -T mailman-core m3c

--- a/src/mailman3commander/__init__.py
+++ b/src/mailman3commander/__init__.py
@@ -2,4 +2,11 @@
 
 __version__ = "0.1.1"
 
-__all__ = ["__version__"]
+from .docker_mailman import add_members, list_lists, list_members
+
+__all__ = [
+    "__version__",
+    "add_members",
+    "list_lists",
+    "list_members",
+]

--- a/src/mailman3commander/docker_mailman.py
+++ b/src/mailman3commander/docker_mailman.py
@@ -1,0 +1,73 @@
+"""Helper functions for running Mailman Core commands via Docker Compose.
+
+These helpers wrap ``docker compose exec -T mailman-core`` invocations to
+allow programmatic interaction with the Mailman CLI from Python. Each
+function returns a tuple ``(stdout, stderr, returncode)`` allowing callers to
+inspect the command result.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Iterable, List, Tuple
+
+CommandResult = Tuple[str, str, int]
+
+
+def _run_mailman(args: List[str], input_data: str | None = None) -> CommandResult:
+    """Run a Mailman command inside the ``mailman-core`` container.
+
+    Parameters
+    ----------
+    args:
+        Additional arguments for the ``mailman`` command.
+    input_data:
+        Optional string passed to ``stdin``. Useful for commands like
+        ``addmembers`` that expect a list of addresses on standard input.
+    """
+    cmd = ["docker", "compose", "exec", "-T", "mailman-core", "mailman"] + args
+    result = subprocess.run(
+        cmd,
+        input=input_data,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def list_lists() -> CommandResult:
+    """List all available mailing lists.
+
+    Returns
+    -------
+    (stdout, stderr, returncode):
+        Output of ``mailman lists``.
+    """
+
+    return _run_mailman(["lists"])
+
+
+def list_members(list_name: str) -> CommandResult:
+    """List members of ``list_name``.
+
+    Parameters
+    ----------
+    list_name:
+        Fully qualified name of the mailing list.
+    """
+
+    return _run_mailman(["members", list_name])
+
+
+def add_members(list_name: str, members: Iterable[str]) -> CommandResult:
+    """Add ``members`` to ``list_name`` using ``mailman addmembers``.
+
+    ``members`` should be an iterable of email addresses. They will be joined
+    with newlines and passed to the command via ``stdin``.
+    """
+
+    data = "\n".join(members) + "\n"
+    # The ``-`` tells Mailman to read addresses from standard input.
+    return _run_mailman(["addmembers", list_name, "-"], input_data=data)
+


### PR DESCRIPTION
## Summary
- add helper functions wrapping `docker compose exec -T mailman-core` commands
- expose helpers from package init and document usage
- include script showing how to reconnect to the container after `setup.sh`

## Testing
- `python -m py_compile src/mailman3commander/docker_mailman.py src/mailman3commander/__init__.py`
- `python -m pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a9aa5017cc832fa29c42b0c6dea4f6